### PR TITLE
Add graphs as message attachments

### DIFF
--- a/commands/graph.js
+++ b/commands/graph.js
@@ -1,4 +1,5 @@
 const request = require("request");
+const QuickChart = require("quickchart-js");
 const sendResponse = require("../utils/sendResponse");
 const sendDeletableResponse = require("../utils/sendDeletableResponse");
 const { MessageAttachment } = require("discord.js")
@@ -82,25 +83,15 @@ module.exports = (message, client) => {
             return sendDeletableResponse("Hm, something went wrong. Was that link really a replay?")
         }
 
-        let postOptions = {
-            uri: "https://quickchart.io/chart/create",
-            headers: {'content-type' : 'application/json'},
-            method: "POST",
-            json: {
-                backgroundColor: "white",
-                width: 700,
-                height: 400,
-                format: "png",
-                chart: graphData,
-                timeout: 10000
-            }
-        };
-        request(postOptions, (err, res, body) => {
-            if(err) {
-                return sendDeletableResponse(message, `I got this error while making the chart: ${err}`);
-            }
+        const chart = new QuickChart()
+            .setHeight(400)
+            .setWidth(700)
+            .setFormat("png")
+            .setBackgroundColor("white")
+            .setConfig(graphData);
 
-            return sendResponse(message, body.url);
-        })
+        chart.getBinary()
+            .then((buffer) => sendResponse(message, new MessageAttachment(buffer)))
+            .catch((err) => sendDeletableResponse(message, `I got this error while making the chart: ${err}`));
     });
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -128,6 +128,14 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
       "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA=="
     },
+    "axios": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "requires": {
+        "follow-redirects": "1.5.10"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -535,6 +543,24 @@
         "to-regex-range": "^5.0.1"
       }
     },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "requires": {
+        "debug": "=3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -779,6 +805,11 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "javascript-stringify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/javascript-stringify/-/javascript-stringify-2.0.1.tgz",
+      "integrity": "sha512-yV+gqbd5vaOYjqlbk16EG89xB5udgjqQF3C5FAORDg4f/IS1Yc5ERCv5e/57yBcfJYw05V5JyIXabhwb75Xxow=="
     },
     "js-levenshtein": {
       "version": "1.1.6",
@@ -1139,6 +1170,15 @@
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+    },
+    "quickchart-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/quickchart-js/-/quickchart-js-1.0.2.tgz",
+      "integrity": "sha512-+PAYVhqgX7d6qFGTGwL7X1sIz58qk46yu0G6eyr4WfREQKon3xHgQNAQglD6DkEFbcvsP4PGviXFF9iHFQOuxg==",
+      "requires": {
+        "axios": "^0.19.2",
+        "javascript-stringify": "^2.0.1"
+      }
     },
     "rc": {
       "version": "1.2.8",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "node-opus": "^0.2.9",
     "node-schedule": "^1.3.2",
     "opusscript": "0.0.6",
+    "quickchart-js": "^1.0.2",
     "request": "^2.88.2",
     "wordpos": "^1.2.0"
   },
@@ -33,8 +34,8 @@
     "node": "10.15.3"
   },
   "respository": {
-      "type": "git",
-      "url": "https://github.com/Euophrys/mahjong-discord-bot.git"
+    "type": "git",
+    "url": "https://github.com/Euophrys/mahjong-discord-bot.git"
   },
   "homepage": "https://github.com/Euophrys/mahjong-discord-bot#readme"
 }

--- a/utils/sendResponse.js
+++ b/utils/sendResponse.js
@@ -1,5 +1,5 @@
 module.exports = (message, response) => {
-    if (response.length > 1800) {
+    if (typeof response === 'string' && response.length > 1800) {
         response = response.substring(0, 1797) + "...";
     }
     


### PR DESCRIPTION
Quickchart.io short links expire after some time, so upload the chart as an attachment so it's persistent. The [`quickchart-js`](https://github.com/typpo/quickchart-js) library is used to make getting the image data easier.

I have no way of testing this, so hopefully it either works or you can use it as a base for a solution if it doesn't.