### PR TITLE
Add initial newlines for Compact mode users

### DIFF
--- a/commands/bubblewrap.js
+++ b/commands/bubblewrap.js
@@ -20,7 +20,7 @@ module.exports = message => {
 
     tiles = shuffle(tiles);
     
-    let messages = ["\n", "\n"]
+    let messages = ["\u200c\n", "\u200c\n"]
 
     for (let i = 0; i < 2; i++) {
         for (let j = 0; j < 4; j++) {

--- a/commands/bubblewrap.js
+++ b/commands/bubblewrap.js
@@ -20,7 +20,7 @@ module.exports = message => {
 
     tiles = shuffle(tiles);
     
-    let messages = ["", ""]
+    let messages = ["\n", "\n"]
 
     for (let i = 0; i < 2; i++) {
         for (let j = 0; j < 4; j++) {


### PR DESCRIPTION
In compact mode, the first line is on the same line as the username, distorting the grid. This PR fixes that by forcing the grid to start on the next line.

![image](https://user-images.githubusercontent.com/16546385/92307779-4aef2a00-ef88-11ea-92d4-8e6731ec069b.png)

This change will result in a blank line between the two messages for Cozy mode users, but at least the experience will be more or less the same for both since the second message gets split by the bot's name in Compact mode as well.