### PR TITLE
graph: Support sanma replays

### DIFF
--- a/commands/graph.js
+++ b/commands/graph.js
@@ -26,6 +26,7 @@ module.exports = (message, client) => {
             return sendDeletableResponse(message, `I got this error while trying to get the replay: ${err}`);
         }
         
+        let playerCount = 4;
         let graphData = {
             type: 'line',
             data: {
@@ -56,12 +57,13 @@ module.exports = (message, client) => {
         
         let matches = 0;
         let match;
-        const nameRegex = /n\d="(.+?)"/g
+        const nameRegex = /n\d="(.*?)"/g
         while (match = nameRegex.exec(body)) {
             graphData.data.datasets[matches].label = decodeURIComponent(match[1]);
             matches++;
             if (matches == 4) break;
         }
+        playerCount = matches;
 
         matches = 0;
         const endRegex = /[AGARI|RYUUKYOKU].+?sc="(.+?)"/g
@@ -82,6 +84,8 @@ module.exports = (message, client) => {
         if (matches == 0) {
             return sendDeletableResponse("Hm, something went wrong. Was that link really a replay?")
         }
+
+        graphData.data.datasets.splice(playerCount);
 
         const chart = new QuickChart()
             .setHeight(400)


### PR DESCRIPTION
The name of the fourth player will be empty for sanma games. This leads the name regex to pick up `" dan=` for the name of the fourth player.

Change the name regex to accept empty names and remove extra datasets (i.e. the fourth player).

Example of current behaviour (output of `!graph http://tenhou.net/0/?log=2021050510gm-0019-1416-2df59d06&tw=1`):

![!graph http://tenhou.net/0/?log=2021050510gm-0019-1416-2df59d06&tw=1](https://user-images.githubusercontent.com/16546385/117093793-83cae300-ad51-11eb-9764-74c1b7d5dc7f.png)

This patch should remove the red line.