### PR TITLE
Actually remove fourth player from sanma graphs

### DIFF
--- a/commands/graph.js
+++ b/commands/graph.js
@@ -58,7 +58,7 @@ module.exports = (message, client) => {
         let matches = 0;
         let match;
         const nameRegex = /n\d="(.*?)"/g
-        while (match = nameRegex.exec(body)) {
+        while ((match = nameRegex.exec(body)) && match[1]) {
             graphData.data.datasets[matches].label = decodeURIComponent(match[1]);
             matches++;
             if (matches == 4) break;


### PR DESCRIPTION
Follow-up to #35 to remove the fourth line, but actually tested this time as promised.

3-player graph:

`!graph http://tenhou.net/0/?log=2021050510gm-0019-1416-2df59d06&tw=1`
![image](https://user-images.githubusercontent.com/16546385/117712403-cf531600-b1c3-11eb-95af-e75b2707c852.png)

4-player graph (still retains current behaviour): 

`!graph http://tenhou.net/0/?log=2021033111gm-0009-1416-331f137e&tw=3&tw=3`
![image](https://user-images.githubusercontent.com/16546385/117712418-d2e69d00-b1c3-11eb-90aa-4d1977009653.png)